### PR TITLE
Optimize [excerpt] and add [cover/covers/pages] option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ restful:
     comments: true
     path: true
     excerpt: false
+    cover: true
     content: false
     keywords: false
     categories: true

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ restful:
   categories: true  # 分类数据
   tags: true        # 标签数据
   post: true        # 文章数据
+  pages: false      # 额外的 Hexo 页面数据, 如 About
 ```
 
 ## Document
@@ -153,3 +154,19 @@ GET /api/articles/:Slug.json
 ###### Response
 
 [/api/articles/javascript-advanced-functions.json](http://www.imys.net/api/articles/javascript-advanced-functions.json)
+
+### Get Implecit Pages
+
+获取来自主题的 Hexo 隐式页面内容，如 About 等。因隐式页面（除 About 等导航栏入口页外）一般在 Hexo 不提供直接访问入口，调用此 API 的开发者需要了解其完整路径，此接口默认关闭。
+
+例如: 
+
+###### Request
+
+```
+GET /api/pages/about.json
+```
+
+###### Response
+
+格式类似于于 Get Post By Slug。

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -15,6 +15,7 @@ module.exports = function (cfg, site) {
                 date: true,
                 updated: true,
                 comments: true,
+                cover: true,
                 path: true,
                 raw: false,
                 excerpt: false,
@@ -47,8 +48,20 @@ module.exports = function (cfg, site) {
                 updated: posts_props('updated', post.updated),
                 comments: posts_props('comments', post.comments),
                 path: posts_props('path', 'api/articles/' + post.slug + '.json'),
-                excerpt: posts_props('excerpt', post.excerpt),
+                excerpt: posts_props('excerpt', function () {
+                    return post.excerpt ? post.excerpt
+                             .replace(/\<(?!img|br).*?\>/g, "")
+                             .replace(/\r?\n|\r/g, '')
+                             .replace(/<img(.*)>/g, ' [Figure] ') : null
+                }),
                 keywords: posts_props('keywords', cfg.keywords),
+                cover: posts_props('cover',  function () {
+                    var results = /<img[^>]+src="?([^"\s]+)"(.*)>/g.exec(post.content);
+                    var imgURL = null;
+                    if (results !== null)
+                        imgURL = results[1];
+                    return imgURL;
+                }),
                 content: posts_props('content', post.content),
                 raw: posts_props('raw', post.raw),
                 categories: posts_props('categories', function () {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -207,6 +207,15 @@ module.exports = function (cfg, site) {
                     comments: post.comments,
                     path: path,
                     excerpt: post.excerpt,
+                    covers: (function () {
+                        var temp,
+                            imgURLs = [],
+                            rex = /<img[^>]+src="?([^"\s]+)"(.*)>/g;
+                        while ( temp = rex.exec( post.content ) ) {
+                            imgURLs.push( temp[1] );
+                        }
+                        return imgURLs.length > 0 ? imgURLs : null
+                    }()),
                     keywords: cfg.keyword,
                     content: post.content,
                     categories: post.categories.map(function (cat) {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -3,6 +3,26 @@
 var pagination = require('hexo-pagination');
 var _pick = require('lodash.pick');
 
+function filterHTMLTags(str) {
+    return str ? str
+            .replace(/\<(?!img|br).*?\>/g, "")
+            .replace(/\r?\n|\r/g, '')
+            .replace(/<img(.*)>/g, ' [Figure] ') : null
+}
+function fetchCovers(str) {
+    var temp,
+        imgURLs = [],
+        rex = /<img[^>]+src="?([^"\s]+)"(.*)>/g;
+    while ( temp = rex.exec( str ) ) {
+        imgURLs.push( temp[1] );
+    }
+    return imgURLs.length > 0 ? imgURLs : null;
+}
+function fetchCover(str) {
+    var covers = fetchCovers(str)
+    return covers ? covers[0] : null; 
+}
+
 module.exports = function (cfg, site) {
 
     var restful = cfg.hasOwnProperty('restful') ? cfg.restful :
@@ -25,7 +45,8 @@ module.exports = function (cfg, site) {
             },
             categories: true,
             tags: true,
-            post: true
+            post: true,
+            pages: false,
         },
 
         posts = site.posts.sort('-date').filter(function (post) {
@@ -48,20 +69,9 @@ module.exports = function (cfg, site) {
                 updated: posts_props('updated', post.updated),
                 comments: posts_props('comments', post.comments),
                 path: posts_props('path', 'api/articles/' + post.slug + '.json'),
-                excerpt: posts_props('excerpt', function () {
-                    return post.excerpt ? post.excerpt
-                             .replace(/\<(?!img|br).*?\>/g, "")
-                             .replace(/\r?\n|\r/g, '')
-                             .replace(/<img(.*)>/g, ' [Figure] ') : null
-                }),
+                excerpt: posts_props('excerpt', filterHTMLTags(post.excerpt)),
                 keywords: posts_props('keywords', cfg.keywords),
-                cover: posts_props('cover',  function () {
-                    var results = /<img[^>]+src="?([^"\s]+)"(.*)>/g.exec(post.content);
-                    var imgURL = null;
-                    if (results !== null)
-                        imgURL = results[1];
-                    return imgURL;
-                }),
+                cover: posts_props('cover',  fetchCover(post.content)),
                 content: posts_props('content', post.content),
                 raw: posts_props('raw', post.raw),
                 categories: posts_props('categories', function () {
@@ -206,21 +216,8 @@ module.exports = function (cfg, site) {
                     updated: post.updated,
                     comments: post.comments,
                     path: path,
-                    excerpt: (function () {
-                    return post.excerpt ? post.excerpt
-                                .replace(/\<(?!img|br).*?\>/g, "")
-                                .replace(/\r?\n|\r/g, '')
-                                .replace(/<img(.*)>/g, ' [Figure] ') : null
-                    })(),
-                    covers: (function () {
-                        var temp,
-                            imgURLs = [],
-                            rex = /<img[^>]+src="?([^"\s]+)"(.*)>/g;
-                        while ( temp = rex.exec( post.content ) ) {
-                            imgURLs.push( temp[1] );
-                        }
-                        return imgURLs.length > 0 ? imgURLs : null
-                    }()),
+                    excerpt: filterHTMLTags(post.excerpt),
+                    covers: fetchCovers(post.content),
                     keywords: cfg.keyword,
                     content: post.content,
                     categories: post.categories.map(function (cat) {
@@ -235,6 +232,27 @@ module.exports = function (cfg, site) {
                             path: 'api/tags/' + tag.name + '.json'
                         };
                     })
+                })
+            };
+        }));
+    }
+
+    if (restful.pages) {
+        apiData = apiData.concat(site.pages.data.map(function (page) {
+            var safe_title = page.title.replace(/[^a-z0-9]/gi, '-').toLowerCase()
+            var path = 'api/pages/' + safe_title + '.json';
+
+            return {
+                path: path,
+                data: JSON.stringify({
+                    title: page.title,
+                    date: page.date,
+                    updated: page.updated,
+                    comments: page.comments,
+                    path: path,
+                    covers: fetchCovers(page.content),
+                    excerpt: filterHTMLTags(page.excerpt),
+                    content: page.content
                 })
             };
         }));

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -206,7 +206,12 @@ module.exports = function (cfg, site) {
                     updated: post.updated,
                     comments: post.comments,
                     path: path,
-                    excerpt: post.excerpt,
+                    excerpt: (function () {
+                    return post.excerpt ? post.excerpt
+                                .replace(/\<(?!img|br).*?\>/g, "")
+                                .replace(/\r?\n|\r/g, '')
+                                .replace(/<img(.*)>/g, ' [Figure] ') : null
+                    })(),
                     covers: (function () {
                         var temp,
                             imgURLs = [],


### PR DESCRIPTION
This PR contains the following changes:

- the results of `excerpt` now filtering HTML tags;
- add `cover` option for posts, which gives the first image URL in a post if the article contains figures;
- add `covers` option for `article/*.json`, this array contains all image URLs for each article.
- add `pages` option for `pages/*.json`, supports implicit Hexo pages contents.