### PR TITLE
Add slug support to filename of category and tag data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ restful:
     keywords: false
     categories: true
     tags: true
-  categories: true  # 分类数据
-  tags: true        # 标签数据
-  post: true        # 文章数据
-  pages: false      # 额外的 Hexo 页面数据, 如 About
+  categories: true         # 分类数据
+  use_category_slug: false # Use slug for filename of category data
+  tags: true               # 标签数据
+  use_tag_slug: false      # Use slug for filename of tag data
+  post: true               # 文章数据
+  pages: false             # 额外的 Hexo 页面数据, 如 About
 ```
 
 ## Document

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -44,7 +44,9 @@ module.exports = function (cfg, site) {
                 tags: true
             },
             categories: true,
+            use_category_slug: false,
             tags: true,
+            use_tag_slug: false,
             post: true,
             pages: false,
         },
@@ -77,32 +79,50 @@ module.exports = function (cfg, site) {
                 raw: posts_props('raw', post.raw),
                 categories: posts_props('categories', function () {
                     return post.categories.map(function (cat) {
+                        const name = (
+                            cfg.restful.use_category_slug && cat.slug
+                        ) ? cat.slug : cat.name;
                         return {
-                            name: cat.name,
-                            path: 'api/categories/' + cat.name + '.json'
+                            name: name,
+                            path: 'api/categories/' + name + '.json'
                         };
                     });
                 }),
                 tags: posts_props('tags', function () {
                     return post.tags.map(function (tag) {
+                        const name = (
+                            cfg.restful.use_tag_slug && tag.slug
+                        ) ? tag.slug : tag.name;
                         return {
-                            name: tag.name,
-                            path: 'api/tags/' + tag.name + '.json'
+                            name: name,
+                            path: 'api/tags/' + name + '.json'
                         };
                     });
                 })
             };
         },
 
-        cateReduce = function (cates, name) {
+        cateReduce = function (cates, kind) {
             return cates.reduce(function (result, item) {
                 if (!item.length) return result;
+
+                let use_slug = null;
+                switch (kind) {
+                    case 'categories':
+                        use_slug = cfg.restful.use_category_slug;
+                        break;
+                    case 'tags':
+                        use_slug = cfg.restful.use_tag_slug;
+                        break;
+                }
+
+                const name = (use_slug && item.slug) ? item.slug : item.name;
 
                 return result.concat(pagination(item.path, posts, {
                     perPage: 0,
                     data: {
-                        name: item.name,
-                        path: 'api/' + name + '/' + item.name + '.json',
+                        name: name,
+                        path: 'api/' + kind + '/' + name + '.json',
                         postlist: item.posts.map(postMap)
                     }
 


### PR DESCRIPTION
Added `use_category_slug` and `use_tag_slug` options.

When the category name or tag name is non-ascii characters, the URL of the JSON file also becomes non-ascii.

With this option you can keep ascii URL using slug.