### PR TITLE
修复page路径问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ restful:
   use_tag_slug: false      # Use slug for filename of tag data
   post: true               # 文章数据
   pages: false             # 额外的 Hexo 页面数据, 如 About
+  pages_exclude:           # 排除页面，如 lib
+    - lib
+    - images
+    - css
+    - js
 ```
 
 ## Document

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -22,6 +22,29 @@ function fetchCover(str) {
     var covers = fetchCovers(str)
     return covers ? covers[0] : null; 
 }
+/*
+* Return
+*    true: <RelativePath> found in <config.restful.pages_exclude>
+*   false: <RelativePath> not found in <config.restful.pages_exclude>
+*/ 
+function isExclude(RelativePath, config) {
+  if (!config.pages_exclude) return false;
+  const P_exclude = config.pages_exclude;
+  const exclude = P_exclude;  
+  if (P_exclude && !Array.isArray(P_exclude)) {
+    exclude = [P_exclude];
+  }
+  // 404/index.md =>  ["404","index.md"]
+  const RPArr = RelativePath.split("/");
+  const RPStr = RPArr[0];
+
+  if (exclude && exclude.length) {
+    for (const i of exclude) {
+      if (RPStr.toLowerCase() === i.toLowerCase()) return true;
+    }
+  }
+  return false;
+}
 
 module.exports = function (cfg, site) {
 
@@ -261,22 +284,27 @@ module.exports = function (cfg, site) {
 
     if (restful.pages) {
         apiData = apiData.concat(site.pages.data.map(function (page) {
-            var safe_title = page.title.replace(/[^a-z0-9]/gi, '-').toLowerCase()
-            var path = 'api/pages/' + safe_title + '.json';
+            if (!isExclude(page.source, restful)) {				
+				/* <page.source> not found in <config.restful.pages_exclude> */
+				//console.log('INFO  Path:' + page.source);    //404/index.md 
+				//var safe_title = page.title.replace(/[^a-z0-9]/gi, '-').toLowerCase()            
+				var page_filename = page.source.replace(/\/index.md/gi, '').toLowerCase();
+				var path = 'api/pages/' + page_filename + '.json';
 
-            return {
-                path: path,
-                data: JSON.stringify({
-                    title: page.title,
-                    date: page.date,
-                    updated: page.updated,
-                    comments: page.comments,
-                    path: path,
-                    covers: fetchCovers(page.content),
-                    excerpt: filterHTMLTags(page.excerpt),
-                    content: page.content
-                })
-            };
+				return {
+					path: path,
+					data: JSON.stringify({
+						title: page.title,
+						date: page.date,
+						updated: page.updated,
+						comments: page.comments,
+						path: path,
+						covers: fetchCovers(page.content),
+						excerpt: filterHTMLTags(page.excerpt),
+						content: page.content
+					})
+				};
+			}
         }));
     }
 


### PR DESCRIPTION
原先的page路径采用的是，内容标题，且非英文和数字的都替换为`-`，将导致about的实际路径并不是这样的`/api/pages/about.json`。

此修复，page路径采用的是`page.source`变量，其值类似 `404/index.md`，取值斜杠前面的，如 `404`。将可正确的获取路径。
并且，`source` 目录下有其它文件夹，并不属于page范畴，在配置中添加选项，可排除。