### PR TITLE
新增节点，设置json文件中是否包含content内容。

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -50,6 +50,7 @@ module.exports = function(cfg, site) {
             use_tag_slug: false,
             post: true,
             pages: false,
+            simple_post_map: false
         },
 
         posts = site.posts.sort('-date').filter(function(post) {
@@ -125,13 +126,16 @@ module.exports = function(cfg, site) {
                 }
 
                 const name = (use_slug && item.slug) ? item.slug : item.name;
+                let simple_post_map = cfg.restful.simple_post_map;
+                //  Select whether to generate content node
+                let postlist = simple_post_map ? item.posts.map(simplepostMap) : item.posts.map(postMap);
 
                 return result.concat(pagination(item.path, posts, {
                     perPage: 0,
                     data: {
                         name: name,
                         path: 'api/' + kind + '/' + name + '.json',
-                        postlist: item.posts.map(simplepostMap)
+                        postlist: postlist
                     }
 
                 }));

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -5,28 +5,29 @@ var _pick = require('lodash.pick');
 
 function filterHTMLTags(str) {
     return str ? str
-            .replace(/\<(?!img|br).*?\>/g, "")
-            .replace(/\r?\n|\r/g, '')
-            .replace(/<img(.*)>/g, ' [Figure] ') : null
+        .replace(/\<(?!img|br).*?\>/g, "")
+        .replace(/\r?\n|\r/g, '')
+        .replace(/<img(.*)>/g, ' [Figure] ') : null
 }
+
 function fetchCovers(str) {
     var temp,
         imgURLs = [],
         rex = /<img[^>]+src="?([^"\s]+)"(.*)>/g;
-    while ( temp = rex.exec( str ) ) {
-        imgURLs.push( temp[1] );
+    while (temp = rex.exec(str)) {
+        imgURLs.push(temp[1]);
     }
     return imgURLs.length > 0 ? imgURLs : null;
 }
+
 function fetchCover(str) {
     var covers = fetchCovers(str)
-    return covers ? covers[0] : null; 
+    return covers ? covers[0] : null;
 }
 
-module.exports = function (cfg, site) {
+module.exports = function(cfg, site) {
 
-    var restful = cfg.hasOwnProperty('restful') ? cfg.restful :
-        {
+    var restful = cfg.hasOwnProperty('restful') ? cfg.restful : {
             site: true,
             posts_size: 10,
             posts_props: {
@@ -51,19 +52,19 @@ module.exports = function (cfg, site) {
             pages: false,
         },
 
-        posts = site.posts.sort('-date').filter(function (post) {
+        posts = site.posts.sort('-date').filter(function(post) {
             return post.published;
         }),
 
-        posts_props = (function () {
+        posts_props = (function() {
             var props = restful.posts_props;
 
-            return function (name, val) {
+            return function(name, val) {
                 return props[name] ? (typeof val === 'function' ? val() : val) : null;
             }
         })(),
 
-        postMap = function (post) {
+        postMap = function(post) {
             return {
                 title: posts_props('title', post.title),
                 slug: posts_props('slug', post.slug),
@@ -77,8 +78,8 @@ module.exports = function (cfg, site) {
                 cover: posts_props('cover', post.cover || fetchCover(post.content)),
                 content: posts_props('content', post.content),
                 raw: posts_props('raw', post.raw),
-                categories: posts_props('categories', function () {
-                    return post.categories.map(function (cat) {
+                categories: posts_props('categories', function() {
+                    return post.categories.map(function(cat) {
                         const name = (
                             cfg.restful.use_category_slug && cat.slug
                         ) ? cat.slug : cat.name;
@@ -88,8 +89,8 @@ module.exports = function (cfg, site) {
                         };
                     });
                 }),
-                tags: posts_props('tags', function () {
-                    return post.tags.map(function (tag) {
+                tags: posts_props('tags', function() {
+                    return post.tags.map(function(tag) {
                         const name = (
                             cfg.restful.use_tag_slug && tag.slug
                         ) ? tag.slug : tag.name;
@@ -101,9 +102,16 @@ module.exports = function (cfg, site) {
                 })
             };
         },
+        simplepostMap = function(post) {
+            return {
+                title: posts_props('title', post.title),
+                slug: posts_props('slug', post.slug),
+                path: posts_props('path', 'api/articles/' + post.slug + '.json'),
 
-        cateReduce = function (cates, kind) {
-            return cates.reduce(function (result, item) {
+            };
+        },
+        cateReduce = function(cates, kind) {
+            return cates.reduce(function(result, item) {
                 if (!item.length) return result;
 
                 let use_slug = null;
@@ -123,14 +131,14 @@ module.exports = function (cfg, site) {
                     data: {
                         name: name,
                         path: 'api/' + kind + '/' + name + '.json',
-                        postlist: item.posts.map(postMap)
+                        postlist: item.posts.map(simplepostMap)
                     }
 
                 }));
             }, []);
         },
 
-        catesMap = function (item) {
+        catesMap = function(item) {
             return {
                 name: item.data.name,
                 path: item.data.path,
@@ -138,7 +146,7 @@ module.exports = function (cfg, site) {
             };
         },
 
-        cateMap = function (item) {
+        cateMap = function(item) {
             var itemData = item.data;
             return {
                 path: itemData.path,
@@ -226,7 +234,7 @@ module.exports = function (cfg, site) {
     }
 
     if (restful.post) {
-        apiData = apiData.concat(posts.map(function (post) {
+        apiData = apiData.concat(posts.map(function(post) {
             var path = 'api/articles/' + post.slug + '.json';
             return {
                 path: path,
@@ -242,13 +250,13 @@ module.exports = function (cfg, site) {
                     keywords: cfg.keyword,
                     content: post.content,
                     more: post.more,
-                    categories: post.categories.map(function (cat) {
+                    categories: post.categories.map(function(cat) {
                         return {
                             name: cat.name,
                             path: 'api/categories/' + cat.name + '.json'
                         };
                     }),
-                    tags: post.tags.map(function (tag) {
+                    tags: post.tags.map(function(tag) {
                         return {
                             name: tag.name,
                             path: 'api/tags/' + tag.name + '.json'
@@ -260,7 +268,7 @@ module.exports = function (cfg, site) {
     }
 
     if (restful.pages) {
-        apiData = apiData.concat(site.pages.data.map(function (page) {
+        apiData = apiData.concat(site.pages.data.map(function(page) {
             var safe_title = page.title.replace(/[^a-z0-9]/gi, '-').toLowerCase()
             var path = 'api/pages/' + safe_title + '.json';
 


### PR DESCRIPTION
新增simple_post_map 节点，以实现在生成tags的时候，是否生成content等内容。
# 对外API
restful:
  site: true        # hexo.config mix theme.config
  posts_size: 10    # 文章列表分页，0 表示不分页
  posts_props:      # 文章列表项的需要生成的属性
    title: true
    slug: true
    date: true
    updated: true
    comments: true
    path: true
    excerpt: false
    cover: true      # 封面图，取文章第一张图片
    content: true
    keywords: true
    categories: true
    tags: true
  categories: true         # 分类数据
  use_category_slug: true # Use slug for filename of category data
  tags: true               # 标签数据
  use_tag_slug: true      # Use slug for filename of tag data
  post: true               # 文章数据
  pages: true
  **simple_post_map: true  #简单格式化,是否序列化content等内容的 开关**